### PR TITLE
Feature/configure column graph lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,5 @@ To run the tests and formatting tools:
 $ mix deps.get
 $ mix test
 $ mix format
-$ mix credo--strict
+$ mix credo --strict
  ```

--- a/uncharted/lib/uncharted/axes/magnitude_axis.ex
+++ b/uncharted/lib/uncharted/axes/magnitude_axis.ex
@@ -2,7 +2,17 @@ defmodule Uncharted.Axes.MagnitudeAxis do
   @moduledoc """
   Exposes a struct representing configuration for an axis that has values that increase in a particular direction
   """
-  defstruct [:min, :max, :step, :label, grid_lines: &__MODULE__.default_grid_lines_fun/2]
+  defstruct [
+    :min,
+    :max,
+    :step,
+    :label,
+    grid_lines: &__MODULE__.default_grid_lines_fun/2,
+    display_lines: true,
+    line_color: "#efefef",
+    line_width: 2
+  ]
+
   @type min :: number()
   @type max :: number()
   @type step :: integer()
@@ -19,7 +29,10 @@ defmodule Uncharted.Axes.MagnitudeAxis do
           max: number(),
           step: integer(),
           label: String.t() | nil,
-          grid_lines: grid_lines_func
+          grid_lines: grid_lines_func,
+          display_lines: boolean(),
+          line_color: String.t() | atom(),
+          line_width: integer()
         }
 
   @doc """

--- a/uncharted_phoenix/README.md
+++ b/uncharted_phoenix/README.md
@@ -218,3 +218,13 @@ colors = %{
   }
 }
 ```
+
+### Configure Grid Line Display
+You can configure the color and width of grid lines, as well as whether or not to display them. Set `line_color` to a string or the atom key of a set base color or gradient (see above). Set `line_width` to an integer to change the width of grid lines. Set `display_lines` to `false` to hide grid lines along that axis. This will work for column charts and the x-axis of line charts.
+```elixir
+%MagnitudeAxis{
+  line_color: "#efefef"
+  line_width: 2,
+  display_lines: true
+}
+```

--- a/uncharted_phoenix/lib/uncharted_phoenix/components/_chart_lines.html.leex
+++ b/uncharted_phoenix/lib/uncharted_phoenix/components/_chart_lines.html.leex
@@ -1,10 +1,14 @@
-<g id="<%= svg_id(@chart, "lines") %>" class="chart-lines">
-  <line x1="0%" y1="0%" x2="0%" y2="100%" stroke="#efefef" stroke-width="2px" stroke-linecap="round" />
-  <line x1="0%" y1="100%" x2="100%" y2="100%" stroke="#efefef" stroke-width="4px" stroke-linecap="round" />
-  <%= for line <- @grid_lines do %>
-    <% offset = @offsetter.(line) %>
-    <line x1="0%" y1="<%= offset %>%" x2="100%" y2="<%= offset %>%" stroke="#efefef" stroke-width="2px" stroke-linecap="round" />
-  <% end %>
-  <line x1="0%" y1="0%" x2="100%" y2="0%" stroke="#efefef" stroke-width="4px" stroke-linecap="round" />
-  <line x1="100%" y1="0%" x2="100%" y2="100%" stroke="#efefef" stroke-width="2px" stroke-linecap="round" />
-</g>
+<% %{display_lines: display, line_color: color, line_width: width} = @axis %>
+<% colors = Chart.colors(@chart) %>
+<%= if display do %>
+  <g id="<%= svg_id(@chart, "lines") %>" class="chart-lines">
+    <line x1="0%" y1="0%" x2="0%" y2="100%" stroke="<%= color_to_fill(colors, color, true) %>" stroke-width="<%= width %>px" stroke-linecap="round" />
+    <line x1="0%" y1="100%" x2="100%" y2="100%" stroke="<%= color_to_fill(colors, color, true) %>" stroke-width="<%= width %>px" stroke-linecap="round" />
+    <%= for line <- @grid_lines do %>
+      <% offset = @offsetter.(line) %>
+      <line x1="0%" y1="<%= offset %>%" x2="100%" y2="<%= offset %>%" stroke="<%= color_to_fill(colors, color, true) %>" stroke-width="<%= width %>px" stroke-linecap="round" />
+    <% end %>
+    <line x1="0%" y1="0%" x2="100%" y2="0%" stroke="<%= color_to_fill(colors, color, true) %>" stroke-width="<%= width %>px" stroke-linecap="round" />
+    <line x1="100%" y1="0%" x2="100%" y2="100%" stroke="<%= color_to_fill(colors, color, true) %>" stroke-width="<%= width %>px" stroke-linecap="round" />
+  </g>
+<% end %>

--- a/uncharted_phoenix/lib/uncharted_phoenix/components/_color_defs.html.leex
+++ b/uncharted_phoenix/lib/uncharted_phoenix/components/_color_defs.html.leex
@@ -4,5 +4,9 @@
       <stop stop-color="<%= start_color %>" offset="0%"></stop>
       <stop stop-color="<%= stop_color %>" offset="100%"></stop>
     </linearGradient>
+    <linearGradient id="<%= Atom.to_string(name) %>_line" gradientUnits="userSpaceOnUse">
+      <stop stop-color="<%= start_color %>" offset="0%"></stop>
+      <stop stop-color="<%= stop_color %>" offset="100%"></stop>
+    </linearGradient>
   <% end %>
 </defs>

--- a/uncharted_phoenix/lib/uncharted_phoenix/components/live_column.ex
+++ b/uncharted_phoenix/lib/uncharted_phoenix/components/live_column.ex
@@ -13,10 +13,13 @@ defmodule UnchartedPhoenix.LiveColumnComponent do
 
     socket =
       socket
-      |> assign(:chart, assigns.chart)
-      |> assign(:columns, Uncharted.ColumnChart.columns(assigns.chart))
-      |> assign(:grid_lines, grid_lines)
-      |> assign(:grid_line_offsetter, grid_line_offsetter)
+      |> assign(%{
+        chart: assigns.chart,
+        columns: Uncharted.ColumnChart.columns(assigns.chart),
+        grid_lines: grid_lines,
+        grid_line_offsetter: grid_line_offsetter,
+        axis: y_axis
+      })
 
     {:ok, socket}
   end

--- a/uncharted_phoenix/lib/uncharted_phoenix/components/live_column.ex
+++ b/uncharted_phoenix/lib/uncharted_phoenix/components/live_column.ex
@@ -13,13 +13,11 @@ defmodule UnchartedPhoenix.LiveColumnComponent do
 
     socket =
       socket
-      |> assign(%{
-        chart: assigns.chart,
-        columns: Uncharted.ColumnChart.columns(assigns.chart),
-        grid_lines: grid_lines,
-        grid_line_offsetter: grid_line_offsetter,
-        axis: y_axis
-      })
+      |> assign(:chart, assigns.chart)
+      |> assign(:columns, Uncharted.ColumnChart.columns(assigns.chart))
+      |> assign(:grid_lines, grid_lines)
+      |> assign(:grid_line_offsetter, grid_line_offsetter)
+      |> assign(:axis, y_axis)
 
     {:ok, socket}
   end

--- a/uncharted_phoenix/lib/uncharted_phoenix/components/live_column.html.leex
+++ b/uncharted_phoenix/lib/uncharted_phoenix/components/live_column.html.leex
@@ -6,7 +6,7 @@
     <%= render "_x_axis.html", chart: @chart, columns: @columns %>
 
     <svg id="<%= svg_id(@chart, "graph") %>" class="chart-lines" width="90%" height="92%" x="10%" y="0">
-      <%= render "_chart_lines.html", chart: @chart, grid_lines: @grid_lines, offsetter: @grid_line_offsetter %>
+      <%= render "_chart_lines.html", chart: @chart, grid_lines: @grid_lines, offsetter: @grid_line_offsetter, axis: @axis %>
       <%= render "_column_chart_graph.html", chart: @chart, columns: @columns %>
     </svg>
     <%= render "_color_defs.html", chart: @chart %>

--- a/uncharted_phoenix/lib/uncharted_phoenix/components/live_line.ex
+++ b/uncharted_phoenix/lib/uncharted_phoenix/components/live_line.ex
@@ -17,13 +17,16 @@ defmodule UnchartedPhoenix.LiveLineComponent do
 
     socket =
       socket
-      |> assign(:chart, assigns.chart)
-      |> assign(:points, Uncharted.LineChart.points(assigns.chart))
-      |> assign(:lines, Uncharted.LineChart.lines(assigns.chart))
-      |> assign(:x_grid_lines, x_grid_lines)
-      |> assign(:x_grid_line_offsetter, x_grid_line_offsetter)
-      |> assign(:y_grid_lines, y_grid_lines)
-      |> assign(:y_grid_line_offsetter, y_grid_line_offsetter)
+      |> assign(%{
+        chart: assigns.chart,
+        points: Uncharted.LineChart.points(assigns.chart),
+        lines: Uncharted.LineChart.lines(assigns.chart),
+        x_grid_lines: x_grid_lines,
+        x_grid_line_offsetter: x_grid_line_offsetter,
+        x_axis: x_axis,
+        y_grid_lines: y_grid_lines,
+        y_grid_line_offsetter: y_grid_line_offsetter
+      })
 
     {:ok, socket}
   end

--- a/uncharted_phoenix/lib/uncharted_phoenix/components/live_line.ex
+++ b/uncharted_phoenix/lib/uncharted_phoenix/components/live_line.ex
@@ -17,16 +17,14 @@ defmodule UnchartedPhoenix.LiveLineComponent do
 
     socket =
       socket
-      |> assign(%{
-        chart: assigns.chart,
-        points: Uncharted.LineChart.points(assigns.chart),
-        lines: Uncharted.LineChart.lines(assigns.chart),
-        x_grid_lines: x_grid_lines,
-        x_grid_line_offsetter: x_grid_line_offsetter,
-        x_axis: x_axis,
-        y_grid_lines: y_grid_lines,
-        y_grid_line_offsetter: y_grid_line_offsetter
-      })
+      |> assign(:chart, assigns.chart)
+      |> assign(:points, Uncharted.LineChart.points(assigns.chart))
+      |> assign(:lines, Uncharted.LineChart.lines(assigns.chart))
+      |> assign(:x_grid_lines, x_grid_lines)
+      |> assign(:x_grid_line_offsetter, x_grid_line_offsetter)
+      |> assign(:x_axis, x_axis)
+      |> assign(:y_grid_lines, y_grid_lines)
+      |> assign(:y_grid_line_offsetter, y_grid_line_offsetter)
 
     {:ok, socket}
   end

--- a/uncharted_phoenix/lib/uncharted_phoenix/components/live_line.html.leex
+++ b/uncharted_phoenix/lib/uncharted_phoenix/components/live_line.html.leex
@@ -8,7 +8,7 @@
     <svg id="<%= svg_id(@chart, "graph") %>" class="chart-lines" width="90%" height="92%" x="10%" y="0">
       <g>
         <%= render "_bar_grid_lines.html", chart: @chart, grid_lines: @x_grid_lines, offsetter: @x_grid_line_offsetter %>
-        <%= render "_chart_lines.html", chart: @chart, grid_lines: @x_grid_lines, offsetter: @x_grid_line_offsetter %>
+        <%= render "_chart_lines.html", chart: @chart, grid_lines: @x_grid_lines, offsetter: @x_grid_line_offsetter, axis: @x_axis %>
         <%= for %Line{start: %{x_offset: x1, y_offset: y1}, end: %{x_offset: x2, y_offset: y2}} <- @lines do %>
           <line
             x1="<%= x1 %>%"

--- a/uncharted_phoenix/lib/uncharted_phoenix/views/component_view.ex
+++ b/uncharted_phoenix/lib/uncharted_phoenix/views/component_view.ex
@@ -10,9 +10,12 @@ defmodule UnchartedPhoenix.ComponentView do
   alias Uncharted.ColumnChart.Column
   alias Uncharted.LineChart.{Line, Point}
 
-  def color_to_fill(colors, name) do
+  def color_to_fill(colors, name, is_line \\ false)
+  def color_to_fill(_, name, _) when is_binary(name), do: name
+
+  def color_to_fill(colors, name, is_line) do
     case Map.get(colors, name) do
-      %Gradient{} -> "url(##{Atom.to_string(name)})"
+      %Gradient{} -> "url(##{Atom.to_string(name) <> if is_line, do: "_line", else: ""})"
       value -> value
     end
   end

--- a/uncharted_phoenix/lib/uncharted_phoenix/views/component_view.ex
+++ b/uncharted_phoenix/lib/uncharted_phoenix/views/component_view.ex
@@ -10,12 +10,10 @@ defmodule UnchartedPhoenix.ComponentView do
   alias Uncharted.ColumnChart.Column
   alias Uncharted.LineChart.{Line, Point}
 
-  def color_to_fill(colors, name, is_line \\ false)
-  def color_to_fill(_, name, _) when is_binary(name), do: name
-
-  def color_to_fill(colors, name, is_line) do
-    case Map.get(colors, name) do
+  def color_to_fill(colors, name, is_line \\ false) do
+    case Map.get(colors, name, nil) do
       %Gradient{} -> "url(##{Atom.to_string(name) <> if is_line, do: "_line", else: ""})"
+      nil -> name
       value -> value
     end
   end

--- a/uncharted_phoenix/test/uncharted_phoenix/components/live_column_test.exs
+++ b/uncharted_phoenix/test/uncharted_phoenix/components/live_column_test.exs
@@ -13,7 +13,28 @@ defmodule UnchartedPhoenix.LiveColumnComponentTest do
       grid_lines: &__MODULE__.grid_line_fun/2
     }
   }
+  @configured_axes %BaseAxes{
+    magnitude_axis: %MagnitudeAxis{
+      min: 0,
+      max: 2500,
+      grid_lines: &__MODULE__.grid_line_fun/2,
+      line_color: "red",
+      line_width: 7
+    }
+  }
+  @nondisplayed_axes %BaseAxes{
+    magnitude_axis: %MagnitudeAxis{
+      min: 0,
+      max: 2500,
+      grid_lines: &__MODULE__.grid_line_fun/2,
+      line_color: "red",
+      line_width: 7,
+      display_lines: false
+    }
+  }
   @base_chart %BaseChart{title: "this title", dataset: %Dataset{axes: @axes, data: []}}
+  @configured_graph_chart %BaseChart{dataset: %Dataset{axes: @configured_axes, data: []}}
+  @nondisplayed_graph_chart %BaseChart{dataset: %Dataset{axes: @nondisplayed_axes, data: []}}
 
   describe "LiveColumnComponent" do
     test "renders" do
@@ -23,6 +44,20 @@ defmodule UnchartedPhoenix.LiveColumnComponentTest do
 
     test "renders the chart's title" do
       assert render_component(LiveColumnComponent, chart: @base_chart) =~ @base_chart.title
+    end
+
+    test "renders grid lines according to configuration" do
+      assert render_component(LiveColumnComponent, chart: @configured_graph_chart) =~
+               "stroke=\"red\""
+
+      assert render_component(LiveColumnComponent, chart: @configured_graph_chart) =~
+               "stroke-width=\"7px\""
+
+      refute render_component(LiveColumnComponent, chart: @nondisplayed_graph_chart) =~
+               "stroke=\"red\""
+
+      refute render_component(LiveColumnComponent, chart: @nondisplayed_graph_chart) =~
+               "stroke-width=\"7px\""
     end
   end
 

--- a/uncharted_phoenix/test/uncharted_phoenix/components/live_line_test.exs
+++ b/uncharted_phoenix/test/uncharted_phoenix/components/live_line_test.exs
@@ -18,7 +18,25 @@ defmodule UnchartedPhoenix.LiveLineComponentTest do
       grid_lines: &__MODULE__.grid_line_fun/2
     }
   }
+  @configured_axes %XYAxes{
+    x: %MagnitudeAxis{
+      min: 0,
+      max: 2500,
+      grid_lines: &__MODULE__.grid_line_fun/2,
+      line_color: "green",
+      line_width: 7
+    },
+    y: %MagnitudeAxis{
+      min: 0,
+      max: 2500,
+      grid_lines: &__MODULE__.grid_line_fun/2
+    }
+  }
   @base_chart %BaseChart{title: "this title", dataset: %Dataset{axes: @axes, data: []}}
+  @configured_chart %BaseChart{
+    title: "this title",
+    dataset: %Dataset{axes: @configured_axes, data: []}
+  }
 
   describe "LiveLineComponent" do
     test "renders" do
@@ -28,6 +46,14 @@ defmodule UnchartedPhoenix.LiveLineComponentTest do
 
     test "renders the chart's title" do
       assert render_component(LiveLineComponent, chart: @base_chart) =~ @base_chart.title
+    end
+
+    test "renders grid lines according to configuration" do
+      assert render_component(LiveLineComponent, chart: @configured_chart) =~
+               "stroke=\"green\""
+
+      assert render_component(LiveLineComponent, chart: @configured_chart) =~
+               "stroke-width=\"7px\""
     end
   end
 


### PR DESCRIPTION
Issues #6, #8, and #7 . Allows user to configure horizontal graph lines for column chart and line graph. Allows for gradients on vertical and horizontal lines by creating two gradients per color. Includes boundary lines, including x and y axis, as part of the graph. With both horizontal and vertical graph lines, has two copies of boundary lines.

Uses `show_gridlines: false `on `BaseAxes`/`XYAxes` to remove lines on both axes and adds `display_lines: false` on `MagnitudeAxis` to hide lines along that axis, including boundary lines. Adds `line_color` and `line_width` to `MagnitudeAxis` to set color and width of lines along that axis.

![examples](https://user-images.githubusercontent.com/36835814/95805157-bbe5d800-0cd2-11eb-9581-100c18e98efd.png)
