### PR TITLE
Create helper render_chart/1 test helper

### DIFF
--- a/uncharted_phoenix/test/support/test_renderer.ex
+++ b/uncharted_phoenix/test/support/test_renderer.ex
@@ -1,0 +1,38 @@
+defmodule UnchartedPhoenix.TestRenderer do
+  import Phoenix.LiveViewTest
+
+  @endpoint Endpoint
+
+  defmodule DummyLiveComponent do
+    @moduledoc """
+    This dummy component is designed to embed a call to the `UnchartedPhoenix` top-level
+    render API so we can write tests against valid inputs to these calls without requiring
+    a fully-mounted LiveView. This prevents us from having to add a lot of overhead because
+    a full LiveView process would require us to setup a router and rely on Phoenix for other
+    dependencies that are not strictly required for UnchartedPhoenix itself.
+    """
+    use Phoenix.LiveComponent
+
+    def render(assigns) do
+      ~L"""
+      <div>
+        <%= if assigns.chart do %>
+          <%= UnchartedPhoenix.render(@socket, assigns.chart) %>
+        <% end %>
+      </div>
+      """
+    end
+  end
+
+  @doc """
+  A helper function for UnchartedPhoenix tests that will render the UnchartedPhoenix
+  component inside of a live component. This will ensure consistency around the way
+  UnchartedPhoenix components are invoked and rendered.
+
+  As long as a valid `Uncharted.gen_chart` is passed in, the chart will be rendered within
+  a dummy LiveView component using LiveViewTest `render_component/3` macro.
+  """
+  def render_chart(chart) do
+    render_component(DummyLiveComponent, chart: chart)
+  end
+end

--- a/uncharted_phoenix/test/uncharted_phoenix/components/live_column_test.exs
+++ b/uncharted_phoenix/test/uncharted_phoenix/components/live_column_test.exs
@@ -2,11 +2,9 @@ defmodule UnchartedPhoenix.LiveColumnComponentTest do
   alias Uncharted.BaseChart
   alias Uncharted.Axes.{BaseAxes, MagnitudeAxis}
   alias Uncharted.ColumnChart.Dataset
-  alias Uncharted.Component
-  alias UnchartedPhoenix.LiveColumnComponent
-  import Phoenix.LiveViewTest
+  import UnchartedPhoenix.TestRenderer
   use ExUnit.Case
-  @endpoint Endpoint
+
   @axes %BaseAxes{
     magnitude_axis: %MagnitudeAxis{
       min: 0,
@@ -39,32 +37,21 @@ defmodule UnchartedPhoenix.LiveColumnComponentTest do
 
   describe "LiveColumnComponent" do
     test "renders" do
-      assert render_component(LiveColumnComponent,
-               chart: @base_chart,
-               id: Component.id(@base_chart)
-             ) =~
-               ~s(data-testid="lc-live-column-component")
+      assert render_chart(@base_chart) =~ ~s(data-testid="lc-live-column-component")
     end
 
     test "renders the chart's title" do
-      assert render_component(LiveColumnComponent,
-               chart: @base_chart,
-               id: Component.id(@base_chart)
-             ) =~ @base_chart.title
+      assert render_chart(@base_chart) =~ @base_chart.title
     end
 
     test "renders grid lines according to configuration" do
-      assert render_component(LiveColumnComponent, chart: @configured_graph_chart) =~
-               "stroke=\"red\""
+      assert render_chart(@configured_graph_chart) =~ "stroke=\"red\""
 
-      assert render_component(LiveColumnComponent, chart: @configured_graph_chart) =~
-               "stroke-width=\"7px\""
+      assert render_chart(@configured_graph_chart) =~ "stroke-width=\"7px\""
 
-      refute render_component(LiveColumnComponent, chart: @nondisplayed_graph_chart) =~
-               "stroke=\"red\""
+      refute render_chart(@nondisplayed_graph_chart) =~ "stroke=\"red\""
 
-      refute render_component(LiveColumnComponent, chart: @nondisplayed_graph_chart) =~
-               "stroke-width=\"7px\""
+      refute render_chart(@nondisplayed_graph_chart) =~ "stroke-width=\"7px\""
     end
   end
 

--- a/uncharted_phoenix/test/uncharted_phoenix/components/live_line_test.exs
+++ b/uncharted_phoenix/test/uncharted_phoenix/components/live_line_test.exs
@@ -1,12 +1,10 @@
 defmodule UnchartedPhoenix.LiveLineComponentTest do
   alias Uncharted.BaseChart
-  alias Uncharted.Component
   alias Uncharted.Axes.{MagnitudeAxis, XYAxes}
   alias Uncharted.LineChart.Dataset
-  alias UnchartedPhoenix.LiveLineComponent
-  import Phoenix.LiveViewTest
+  import UnchartedPhoenix.TestRenderer
   use ExUnit.Case
-  @endpoint Endpoint
+
   @axes %XYAxes{
     x: %MagnitudeAxis{
       min: 0,
@@ -41,21 +39,17 @@ defmodule UnchartedPhoenix.LiveLineComponentTest do
 
   describe "LiveLineComponent" do
     test "renders" do
-      assert render_component(LiveLineComponent, chart: @base_chart, id: Component.id(@base_chart)) =~
-               ~s(data-testid="lc-live-line-component")
+      assert render_chart(@base_chart) =~ ~s(data-testid="lc-live-line-component")
     end
 
     test "renders the chart's title" do
-      assert render_component(LiveLineComponent, chart: @base_chart, id: Component.id(@base_chart)) =~
-               @base_chart.title
+      assert render_chart(@base_chart) =~ @base_chart.title
     end
 
     test "renders grid lines according to configuration" do
-      assert render_component(LiveLineComponent, chart: @configured_chart) =~
-               "stroke=\"green\""
+      assert render_chart(@configured_chart) =~ "stroke=\"green\""
 
-      assert render_component(LiveLineComponent, chart: @configured_chart) =~
-               "stroke-width=\"7px\""
+      assert render_chart(@configured_chart) =~ "stroke-width=\"7px\""
     end
   end
 

--- a/uncharted_phoenix/test/uncharted_phoenix/components/live_pie_test.exs
+++ b/uncharted_phoenix/test/uncharted_phoenix/components/live_pie_test.exs
@@ -1,21 +1,16 @@
 defmodule UnchartedPhoenix.LivePieComponentTest do
-  alias Uncharted.Component
   alias Uncharted.PieChart.Dataset
-  alias UnchartedPhoenix.LivePieComponent
-  import Phoenix.LiveViewTest
+  import UnchartedPhoenix.TestRenderer
   use ExUnit.Case
-  @endpoint Endpoint
   @base_chart %Uncharted.BaseChart{title: "this title", dataset: %Dataset{data: []}}
 
   describe "LivePie" do
     test "renders pie" do
-      assert render_component(LivePieComponent, chart: @base_chart, id: Component.id(@base_chart)) =~
-               ~s(data-testid="lc-live-pie-component")
+      assert render_chart(@base_chart) =~ ~s(data-testid="lc-live-pie-component")
     end
 
     test "renders a chart's title" do
-      assert render_component(LivePieComponent, chart: @base_chart, id: Component.id(@base_chart)) =~
-               @base_chart.title
+      assert render_chart(@base_chart) =~ @base_chart.title
     end
   end
 end

--- a/uncharted_phoenix/test/uncharted_phoenix/components/live_progress_test.exs
+++ b/uncharted_phoenix/test/uncharted_phoenix/components/live_progress_test.exs
@@ -1,13 +1,10 @@
 defmodule UnchartedPhoenix.LiveProgressComponentTest do
   alias Uncharted.BaseChart
-  alias Uncharted.Component
   alias Uncharted.ProgressChart
   alias Uncharted.ProgressChart.Dataset
-  alias UnchartedPhoenix.LiveProgressComponent
-  import Phoenix.LiveViewTest
+  import UnchartedPhoenix.TestRenderer
   use ExUnit.Case
 
-  @endpoint NotAThingYet
   @chart %BaseChart{
     title: "my progress chart",
     colors: %{gray: "#e2e2e2"},
@@ -24,18 +21,15 @@ defmodule UnchartedPhoenix.LiveProgressComponentTest do
 
   describe "LiveProgress component" do
     test "render/1 mounts successfully" do
-      assert render_component(LiveProgressComponent, chart: @chart, id: Component.id(@chart)) =~
-               ~s(data-testid="lc-live-progress-component")
+      assert render_chart(@chart) =~ ~s(data-testid="lc-live-progress-component")
     end
 
     test "renders title for accessibility" do
-      assert render_component(LiveProgressComponent, chart: @chart, id: Component.id(@chart)) =~
-               @chart.title
+      assert render_chart(@chart) =~ @chart.title
     end
 
     test "it renders the percentage" do
-      assert render_component(LiveProgressComponent, chart: @chart, id: Component.id(@chart)) =~
-               "#{ProgressChart.progress(@chart)}"
+      assert render_chart(@chart) =~ "#{ProgressChart.progress(@chart)}"
     end
   end
 end

--- a/uncharted_phoenix/test/uncharted_phoenix_test.exs
+++ b/uncharted_phoenix/test/uncharted_phoenix_test.exs
@@ -1,10 +1,9 @@
 defmodule UnchartedPhoenixTest do
   use ExUnit.Case
-  import Phoenix.LiveViewTest
+  import UnchartedPhoenix.TestRenderer
   alias Uncharted.Axes.{BaseAxes, MagnitudeAxis}
   alias Uncharted.PieChart
 
-  @endpoint ThisIsOnlyNeededForLiveViewTest
   @base_chart %Uncharted.BaseChart{title: "base"}
   @axes %BaseAxes{
     magnitude_axis: %MagnitudeAxis{
@@ -14,33 +13,11 @@ defmodule UnchartedPhoenixTest do
     }
   }
 
-  defmodule DummyLiveComponent do
-    @moduledoc """
-    This dummy component is designed to embed a call to the `UnchartedPhoenix` top-level
-    render API so we can write tests against valid inputs to these calls without requiring
-    a fully-mounted LiveView. This prevents us from having to add a lot of overhead because
-    a full LiveView process would require us to setup a router and rely on Phoenix for other
-    dependencies that are not strictly required for UnchartedPhoenix itself.
-    """
-    use Phoenix.LiveComponent
-
-    def render(assigns) do
-      ~L"""
-      <div>
-        <%= if assigns.chart do %>
-          <%= UnchartedPhoenix.render(@socket, assigns.chart) %>
-        <% end %>
-      </div>
-      """
-    end
-  end
-
   describe "render/3" do
     test "creates pie chart components" do
       pie_chart = %Uncharted.BaseChart{@base_chart | dataset: %PieChart.Dataset{data: []}}
 
-      assert render_component(DummyLiveComponent, chart: pie_chart) =~
-               ~s(data-testid="lc-live-pie-component")
+      assert render_chart(pie_chart) =~ ~s(data-testid="lc-live-pie-component")
     end
 
     test "creates bar chart components" do
@@ -49,8 +26,7 @@ defmodule UnchartedPhoenixTest do
         | dataset: %Uncharted.BarChart.Dataset{data: [], axes: @axes}
       }
 
-      assert render_component(DummyLiveComponent, chart: bar_chart) =~
-               ~s(data-testid="lc-live-bar-component")
+      assert render_chart(bar_chart) =~ ~s(data-testid="lc-live-bar-component")
     end
 
     test "creates column chart components" do
@@ -59,8 +35,7 @@ defmodule UnchartedPhoenixTest do
         | dataset: %Uncharted.ColumnChart.Dataset{data: [], axes: @axes}
       }
 
-      assert render_component(DummyLiveComponent, chart: column_chart) =~
-               ~s(data-testid="lc-live-column-component")
+      assert render_chart(column_chart) =~ ~s(data-testid="lc-live-column-component")
     end
 
     test "creates line chart components" do
@@ -71,28 +46,20 @@ defmodule UnchartedPhoenixTest do
         | dataset: %Uncharted.LineChart.Dataset{axes: xy_axes, data: []}
       }
 
-      assert render_component(DummyLiveComponent, chart: line_chart) =~
-               ~s(data-testid="lc-live-line-component")
+      assert render_chart(line_chart) =~ ~s(data-testid="lc-live-line-component")
     end
 
     test "creates progress chart components" do
       dataset = %Uncharted.ProgressChart.Dataset{to_value: 100, current_value: 50}
 
-      assert render_component(DummyLiveComponent,
-               chart_type: :progress,
-               chart: %Uncharted.BaseChart{@base_chart | dataset: dataset}
-             ) =~
+      assert render_chart(%Uncharted.BaseChart{@base_chart | dataset: dataset}) =~
                ~s(data-testid="lc-live-progress-component")
     end
 
     test "raises an UnchartedPhoenix.ComponentUndefinedError exception when an invalid chart type is given" do
       assert_raise UnchartedPhoenix.ComponentUndefinedError,
                    ~r/^No UnchartedPhoenix Component defined for dataset/,
-                   fn ->
-                     render_component(DummyLiveComponent,
-                       chart: @base_chart
-                     )
-                   end
+                   fn -> render_chart(@base_chart) end
     end
   end
 


### PR DESCRIPTION
This MR introduces an `UnchartedPhoenix.TestRenderer` module that is meant to be imported into test files for UnchartedPhoenix in place of using LiveViewTests's `live_component/3` macro. 

The `UnchartedPhoenix.TestRenderer` module exposes a `render_chart/1` function that can take in any Uncharted chart type and render it using the appropriate UnchartedPhoenix live component. This is predicated on the `Uncharted.Component` protocol being implemented for the chart type you are trying to render.

The `render_chart/1` function will pipe everything through a call to `UnchartedPhoenix.render/2`, ensuring that component ids are added to the component, thus preventing us from having to manually pass an `id: #{some_value}` option to every call to `live_component/3` we would otherwise need to test our LiveView components.