### PR TITLE
allow users to specify fill-opacity for each scatter plot point

### DIFF
--- a/uncharted/lib/uncharted/base_datum.ex
+++ b/uncharted/lib/uncharted/base_datum.ex
@@ -2,11 +2,12 @@ defmodule Uncharted.BaseDatum do
   @moduledoc """
   Exposes a struct representing a basic data point
   """
-  defstruct [:name, :fill_color, :values]
+  defstruct [:name, :fill_color, :fill_opacity, :values]
 
   @type t() :: %__MODULE__{
           name: String.t(),
           fill_color: atom(),
+          fill_opacity: float(),
           values: list(number)
         }
 end

--- a/uncharted/lib/uncharted/scatter_plot/base_chart_impl.ex
+++ b/uncharted/lib/uncharted/scatter_plot/base_chart_impl.ex
@@ -19,6 +19,7 @@ defimpl Uncharted.ScatterPlot, for: Uncharted.BaseChart do
       %Point{
         label: datum.name,
         fill_color: datum.fill_color,
+        fill_opacity: datum.fill_opacity || Point.__struct__().fill_opacity,
         radius: Enum.at(datum.values, 2) || Point.__struct__().radius,
         x_offset: x_offset,
         y_offset: y_offset,

--- a/uncharted/lib/uncharted/scatter_plot/point.ex
+++ b/uncharted/lib/uncharted/scatter_plot/point.ex
@@ -3,11 +3,21 @@ defmodule Uncharted.ScatterPlot.Point do
   A struct representing a Point on an x, y coordinate chart
   """
 
-  defstruct [:label, :fill_color, :x_offset, :y_offset, :x_value, :y_value, radius: 6]
+  defstruct [
+    :label,
+    :fill_color,
+    :x_offset,
+    :y_offset,
+    :x_value,
+    :y_value,
+    radius: 6,
+    fill_opacity: 0.6
+  ]
 
   @type t :: %__MODULE__{
           label: String.t(),
           fill_color: atom(),
+          fill_opacity: float(),
           x_offset: float(),
           y_offset: float(),
           x_value: float(),

--- a/uncharted_phoenix/lib/uncharted_phoenix/components/live_scatter.html.leex
+++ b/uncharted_phoenix/lib/uncharted_phoenix/components/live_scatter.html.leex
@@ -18,10 +18,10 @@
 
         </svg>
         <g id="<%= svg_id(@chart, "dots") %>" class="line_dots">
-          <%= for %ScatterPoint{radius: radius, x_offset: x_offset, y_offset: y_offset, fill_color: fill_color} <- @points do %>
+          <%= for %ScatterPoint{radius: radius, x_offset: x_offset, y_offset: y_offset, fill_color: fill_color, fill_opacity: fill_opacity} <- @points do %>
             <circle
               fill="<%= color_to_fill(@chart.colors(), fill_color) %>"
-              fill-opacity="0.6"
+              fill-opacity="<%= fill_opacity %>"
               cx="<%= x_offset %>%"
               cy="<%= 100 - y_offset %>%"
               r="<%= radius %>">


### PR DESCRIPTION
users can now set a fill-opacity for each plot point, but a default is used if the user don't care